### PR TITLE
Support destroying a user's session in Rails 5.2

### DIFF
--- a/lib/rapid_rack/default_receiver.rb
+++ b/lib/rapid_rack/default_receiver.rb
@@ -23,7 +23,7 @@ module RapidRack
     end
 
     def logout(env)
-      env['rack.session'].clear
+      env['rack.session'].destroy
       redirect_to('/')
     end
   end


### PR DESCRIPTION
`ActionDispatch::Request::Session.clear` stopped working on Rails 5.2. Calling `destroy` has the intended behaviour.